### PR TITLE
Updates on skupper install  and deploy workload roles

### DIFF
--- a/.github/workflows/run_hello.yml
+++ b/.github/workflows/run_hello.yml
@@ -57,6 +57,8 @@ jobs:
 
       # Run Tests
       - name: Run Hello World Test
+        env:
+          ANSIBLE_PYTHON_INTERPRETER: /usr/bin/python3.11
         run: |
           export KUBECONFIG=~/.kube/config
           make hello

--- a/.github/workflows/run_hello.yml
+++ b/.github/workflows/run_hello.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
+          architecture: x64
 
       # Running MAKEFILE to build the collection
       - name: Running MAKEFILE
@@ -58,7 +59,7 @@ jobs:
       # Run Tests
       - name: Run Hello World Test
         env:
-          ANSIBLE_PYTHON_INTERPRETER: /usr/bin/python3.11
+          ANSIBLE_PYTHON_INTERPRETER: python3
         run: |
           export KUBECONFIG=~/.kube/config
           make hello

--- a/.github/workflows/run_hello.yml
+++ b/.github/workflows/run_hello.yml
@@ -64,7 +64,7 @@ jobs:
       # Archive Test Results
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: test_results/

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -59,7 +59,7 @@ jobs:
       # Archive Test Results
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: test_results/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ROOT_PATH := $(shell pwd)
 COLLECTION_PATH := $(ROOT_PATH)/collections/ansible_collections/rhsiqe/skupper
-TAR_NAME := rhsiqe-skupper-0.1.9.tar.gz
+TAR_NAME := rhsiqe-skupper-0.1.10.tar.gz
 TAR_PATH := $(COLLECTION_PATH)/$(TAR_NAME)
 
 build:

--- a/collections/ansible_collections/rhsiqe/skupper/galaxy.yml
+++ b/collections/ansible_collections/rhsiqe/skupper/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: rhsiqe
 name: skupper
-version: 0.1.9
+version: 0.1.10
 readme: README.md
 authors:
   - Rafael Zago <rafaelvzago@gmail.com>

--- a/collections/ansible_collections/rhsiqe/skupper/roles/access_grant/tasks/main.yml
+++ b/collections/ansible_collections/rhsiqe/skupper/roles/access_grant/tasks/main.yml
@@ -52,20 +52,17 @@
   retries: 10
   delay: 10
 
-- name: Wait for Skupper router pods to be ready
-  kubernetes.core.k8s_info:
-    kubeconfig: "{{ kubeconfig }}"
-    kind: Pod
-    namespace: "{{ namespace }}"
-  register: skupper_pods
-
 - name: Wait for all pods in the namespace to be in Running state
   kubernetes.core.k8s_info:
     kubeconfig: "{{ kubeconfig }}"
     kind: Pod
-    namespace: "{{ skupper_site_namespace }}"
+    namespace: "{{ namespace }}"
+    label_selectors:
+      - app.kubernetes.io/part-of in (skupper, skupper-network-observer)
   register: skupper_pods
-  until: skupper_pods.resources | map(attribute='status.phase') | select('equalto', 'Running') | list | length == skupper_pods.resources | length
+  until: >
+    (skupper_pods.resources | length > 0) and
+    (skupper_pods.resources | map(attribute='status.phase') | select('equalto', 'Running') | list | length == skupper_pods.resources | length)
   retries: 30
   delay: 10
 

--- a/collections/ansible_collections/rhsiqe/skupper/roles/deploy_workload/tasks/main.yml
+++ b/collections/ansible_collections/rhsiqe/skupper/roles/deploy_workload/tasks/main.yml
@@ -60,8 +60,10 @@
     kubeconfig: "{{ kubeconfig }}"
     kind: Pod
     namespace: "{{ namespace }}"
+    label_selectors:
+      - app={{ deploy_workload_deployment_name }}
   register: workload_pods
-  until: workload_pods.resources | map(attribute='status.phase') | select('equalto', 'Running') 
+  until: workload_pods.resources | selectattr('status.phase', 'equalto', 'Running') | list | length == deploy_workload_replicas
   retries: 30
   delay: 10
 

--- a/collections/ansible_collections/rhsiqe/skupper/roles/install_skupper/defaults/main.yml
+++ b/collections/ansible_collections/rhsiqe/skupper/roles/install_skupper/defaults/main.yml
@@ -4,4 +4,4 @@ install_skupper_version: 'v2'                                                   
 install_skupper_skupper_release_name: skupper-setup                                 # Skupper release name
 install_skupper_install_output_path: "/tmp/localhost"                               # Must be set in the playbook or inventory
 install_skupper_scope: cluster                                                      # Skupper scope or namespace
-install_skupper_namespace: ""                                                       # Skupper namespace 
+install_skupper_namespace: "skupper-operator"                                       # Skupper namespace 

--- a/collections/ansible_collections/rhsiqe/skupper/roles/install_skupper/tasks/main.yml
+++ b/collections/ansible_collections/rhsiqe/skupper/roles/install_skupper/tasks/main.yml
@@ -68,7 +68,7 @@
     namespace: "{{ install_skupper_namespace | default('skupper') }}"
     kubeconfig: "{{ kubeconfig }}"
     label_selectors:
-      - app.kubernetes.io/part-of=skupper
+      - app.kubernetes.io/part-of in (skupper, skupper-network-observer)
   register: skupper_pods_info
   retries: 30
   delay: 5

--- a/collections/ansible_collections/rhsiqe/skupper/roles/install_skupper/tasks/main.yml
+++ b/collections/ansible_collections/rhsiqe/skupper/roles/install_skupper/tasks/main.yml
@@ -15,25 +15,60 @@
     version: "{{ install_skupper_version }}"
     update: true
 
-- name: Install Skupper using Helm
+- name: Generating HELM files
+  ansible.builtin.command:
+    cmd: make generate-skupper-helm-chart
+    chdir: "{{ skupper_folder }}"
+  register: generate_helm_files
+
+- name: Print the output of the command
+  ansible.builtin.debug:
+    msg: "{{ generate_helm_files.stdout_lines }}"
+
+- name: Install Skupper using Helm Namespace Scope
   kubernetes.core.helm:
-    chart_ref: "{{ skupper_folder }}/charts/skupper-setup"
+    chart_ref: "{{ skupper_folder }}/charts/skupper"
     name: "{{ install_skupper_skupper_release_name }}"
-    namespace: "{{ install_skupper_namespace | default('default') }}"
-    wait: true
-    replace: false
     kubeconfig: "{{ kubeconfig }}"
     values:
       scope: "{{ install_skupper_scope }}"
+    wait: true
+    replace: false
+    namespace: "{{ install_skupper_namespace }}"
+  when: install_skupper_scope  == 'namespace'
+  ignore_errors: true
+
+- name: Create skupper-operator namespace based on the value of install_skupper_operator_namespace
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ install_skupper_namespace }}"
+    kubeconfig: "{{ kubeconfig }}"
+  when: install_skupper_scope == 'cluster'
+
+- name: Install Skupper using Helm (Cluster Scope)
+  kubernetes.core.helm:
+    chart_ref: "{{ skupper_folder }}/charts/skupper"
+    name: "{{ install_skupper_skupper_release_name }}"
+    kubeconfig: "{{ kubeconfig }}"
+    values:
+      scope: "{{ install_skupper_scope }}"
+    wait: true
+    replace: false
+    release_namespace: "{{ install_skupper_namespace }}"
+  when: install_skupper_scope == 'cluster'
   ignore_errors: true
 
 - name: Validate Skupper controller pod status
   kubernetes.core.k8s_info:
     api_version: v1
     kind: Pod
-    namespace: skupper
     namespace: "{{ install_skupper_namespace | default('skupper') }}"
     kubeconfig: "{{ kubeconfig }}"
+    label_selectors:
+      - app.kubernetes.io/part-of=skupper
   register: skupper_pods_info
   retries: 30
   delay: 5
@@ -42,7 +77,7 @@
     - skupper_pods_info.resources is defined
     - (skupper_pods_info.resources | selectattr('metadata.name', 'regex', 'skupper-controller') | list | length) > 0
     - (skupper_pods_info.resources | selectattr('metadata.name', 'regex', 'skupper-controller') | selectattr('status.phase', '==', 'Running') | list | length) > 0
-  failed_when: false 
+  failed_when: false
 
 - name: Clean up Skupper repository directory
   ansible.builtin.file:

--- a/collections/ansible_collections/rhsiqe/skupper/roles/skupper_site/tasks/main.yml
+++ b/collections/ansible_collections/rhsiqe/skupper/roles/skupper_site/tasks/main.yml
@@ -35,9 +35,13 @@
   kubernetes.core.k8s_info:
     kubeconfig: "{{ kubeconfig }}"
     kind: Pod
-    namespace: "{{ skupper_site_namespace }}"
+    namespace: "{{ namespace }}"
+    label_selectors:
+      - app.kubernetes.io/part-of in (skupper, skupper-network-observer)
   register: skupper_pods
-  until: skupper_pods.resources | map(attribute='status.phase') | select('equalto', 'Running') | list | length == skupper_pods.resources | length
+  until: >
+    (skupper_pods.resources | length > 0) and
+    (skupper_pods.resources | map(attribute='status.phase') | select('equalto', 'Running') | list | length == skupper_pods.resources | length)
   retries: 30
   delay: 10
 

--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -13,4 +13,4 @@ collections:
     version: 3.2.0
 
   - name: rhsiqe.skupper
-    version: 0.1.9
+    version: 0.1.10

--- a/docs/roles/deploy_workload.md
+++ b/docs/roles/deploy_workload.md
@@ -10,6 +10,8 @@ This Ansible role automates the deployment of a workload in a Kubernetes cluster
   - Creates a Deployment resource with the specified replicas and container image.
 - **Wait for Deployment Readiness:**
   - Ensures the workload is running by verifying pod statuses.
+  - Based on the label app: <deploy_workload_deployment_name>
+  - Based on the number of replicas: <deploy_workload_replicas>
 - **Display Pod Information:**
   - Outputs the names of the running pods for the deployed workload.
 

--- a/docs/roles/install_skupper.md
+++ b/docs/roles/install_skupper.md
@@ -10,6 +10,7 @@ This Ansible role automates the installation of Skupper using its Helm chart, en
   - Deploys Skupper in the specified Kubernetes namespace using the Helm chart.
   - There are two installation modes: `cluster` and `namespace`.
     - `cluster`: Installs Skupper in the entire Kubernetes cluster.
+        - The skupper controller namespace needs to be specified in the `skupper_namespace` variable.
     - `namespace`: Installs Skupper in a specific namespace.
 - **Clean Up Temporary Directory:**
   - Removes the cloned repository to maintain a clean environment.
@@ -31,7 +32,7 @@ This Ansible role automates the installation of Skupper using its Helm chart, en
 | `install_skupper_skupper_release_name`| `skupper-setup`                           | Release name for Skupper.                                                  |
 | `install_skupper_install_output_path` | `/tmp/localhost`                          | Directory where the repository will be cloned temporarily.                 |
 | `install_skupper_scope`               | `cluster`                                 | Scope of the Skupper installation (cluster or namespace).                  |
-| `skupper_namespace`                   | `default`                                 | Kubernetes namespace for Skupper installation.                             |
+| `skupper_namespace`                   | `default`                                 | Kubernetes namespace for Skupper installation. If `cluster`, specify the namespace where the Skupper controller will be deployed. |
 
 ## Example Usage
 
@@ -72,6 +73,7 @@ skupper_namespace: "west-namespace"
 - The new Helm-based installation method simplifies the deployment and management of Skupper in Kubernetes clusters.
 - Ensure the `kubernetes.core.helm` plugin is installed and properly configured on the control node.
 - This role supports Helm version 3 and above, leveraging its capabilities for reliable Kubernetes deployments.
+- The role will check the pods in the specified namespace to ensure that the Skupper controller is running successfully based on the labelSelector=app.kubernetes.io/part-of=skupper
 
 ## License
 

--- a/scenarios/hello-world/hello-world.yml
+++ b/scenarios/hello-world/hello-world.yml
@@ -43,6 +43,7 @@
         name: rhsiqe.skupper.install_skupper
       when:
         - not skip_skupper_install | default(false) | bool
+        - "'west' in inventory_hostname"
       vars:
         install_skupper_install_output_path: "{{ temp_dir_path }}"
 

--- a/scenarios/hello-world/inventory/host_vars/east.yml
+++ b/scenarios/hello-world/inventory/host_vars/east.yml
@@ -5,13 +5,6 @@ kubeconfig: "{{ ansible_env.HOME }}/.kube/config"
 # Namespace configuration
 namespace_name: hello-world-east
 
-# Installation configuration for Skupper
-install_skupper_skupper_repository: 'https://github.com/skupperproject/skupper.git'
-install_skupper_version: '2.0.0-preview-2'
-install_skupper_skupper_release_name: skupper-setup
-install_skupper_scope: namespace
-install_skupper_namespace: "{{ namespace_prefix }}-{{ namespace_name }}"
-
 # Deployment configuration for workload
 deploy_workload_workload_image: "{{ skupper_test_image_hello_world_backend }}"
 deploy_workload_deployment_name: "backend"

--- a/scenarios/hello-world/inventory/host_vars/west.yml
+++ b/scenarios/hello-world/inventory/host_vars/west.yml
@@ -7,10 +7,10 @@ namespace_name: hello-world-west
 
 # Installation configuration for Skupper
 install_skupper_skupper_repository: 'https://github.com/skupperproject/skupper.git'
-install_skupper_version: '2.0.0-preview-2'
+install_skupper_version: '2.0.0-rc1'
 install_skupper_skupper_release_name: skupper-setup
-install_skupper_scope: namespace
-install_skupper_namespace: "{{ namespace_prefix }}-{{ namespace_name }}"
+install_skupper_scope: cluster
+install_skupper_namespace: "skupper-operator"
 
 # Deployment configuration for workload
 deploy_workload_workload_image: "{{ skupper_test_image_hello_world_frontend }}"


### PR DESCRIPTION
## Description
Bumping version to 0.1.10
feat(skupper): Implement namespace and cluster scope installation
fix(deploy_workload): Ensure all replicas are running before proceeding
Changing the hello world example to adapt to the changes made on the
following roles:

## Motivation and Context

This commit refactors the Skupper installation role to support both namespace
and cluster-scoped deployments.  This provides greater flexibility for users
and aligns with best practices for Kubernetes deployments.

*   Defaulting to the 'skupper-operator' namespace.
*   Dynamically generating the Skupper Helm chart using a Makefile.
*   Adding conditional logic to handle namespace and cluster scope
installations.
*   Improving pod validation by using labels and the dynamic namespace.

This commit enhances the deploy_workload role's readiness check by ensuring
that all replicas of the deployment are running before proceeding.
Previously, the task would succeed if *any* pod was running.

*   Added a label selector (`app={{ deploy_workload_deployment_name }}`) to
target the correct pods.
*   Modified the `until` condition to check if the number of
running pods matches `deploy_workload_replicas`.

This change ensures that the deployment is fully up and running before
the playbook continues.

hanging the hello world example to adapt to the changes made on the
following roles:

- install_skupper
- deploy_workload

This change is needed to use the new variables defined at the roles that
will allow the installation of skupper to work properly and also
identify either the workload deploy and skupper deploy to be identified
by it's labels and count.


## How Has This Been Tested?

```bash
make build
make hello
```

## Types of Changes

- [X] Bug fix
- [X] New feature
- [X] Documentation change

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
